### PR TITLE
Translate simple Jed style translations in JS code

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ As such, the i18nify transform is a small part of a bigger i18n implementation t
 - Keep the HTML templates as clear and readable as possible.
 - As much as possible, do the work of translating up front, at build time.
 
-**SOLD! SHOW ME AN EXAMPLE APP!**
-https://github.com/tableflip/i18n-browserify
+**SOLD! SHOW ME AN EXAMPLE APP!**  
+[https://github.com/tableflip/i18n-browserify](https://github.com/tableflip/i18n-browserify)
 
 ### gettext
 The `gettext` api supports simple text-replacement translations and locale-sensitive pluralization. This app uses [jed.js](http://slexaxton.github.io/Jed/) to provided a `gettext` compatible api for front-end code.
@@ -116,13 +116,18 @@ Standard handlebars style variable substitution is supported, so:
 The translation is done first, and then the templates standard variable substitution fills out the `{{name}}` at run time...
 
 ### Simple translations at build time
-The `data-i18n` magic is done at build time. The `118ify` transform is used with browserify to process the templates, translating the text content of the elements before handing over to the handlebars transform, that converts the html into a javascript function. As the translation happens before the templates are compiled, the standard handlebars variable substitution still works, even within phrases that are translated.
+The `data-i18n` magic is done at build time. The `i18ify` transform is used with browserify to process the templates, translating the text content of the elements before handing over to the handlebars transform, that converts the html into a javascript function. As the translation happens before the templates are compiled, the standard handlebars variable substitution still works, even within phrases that are translated.
 
 As such these translations are done up-front, before deployment, creating language specific app bundles, via browserify:
 
 ```sh
 "bundle_es": "browserify app.js -o dist/es/bundle.js -t [ i18ify --lang es ] -t hbsfy",
 ```
+
+#### In code Jed translations at build time
+If you use a jed compatible API and call your localisation var `i18n`, the i18nify transform will also translate calls to simple translations in your code.
+
+For example, `i18n.translate('some key').fetch()` will be replaced with `'some key'` (or the translation for "some key").
 
 ### Context sensitive translations at runtime
 Some phrases can only be translated when we know the value of the variables in them. The most common case is pluralisation, where the number of things changes at run time, _"There is 1 new alert"_ vs _"There are 3 new alerts"_

--- a/code.js
+++ b/code.js
@@ -1,0 +1,47 @@
+/*
+* i18ify.code - used at build time to replace text in JS.
+*/
+var through = require('through2')
+var split = require('split')
+var duplexer = require('duplexer')
+var i18n = require('./i18n')
+
+module.exports = function (dict, file, opts) {
+  if (!isCode(file)) return through()
+
+  opts = opts || {}
+
+  var sp = split()
+  var tr = translator(dict, file, opts)
+
+  sp.pipe(tr)
+
+  return duplexer(sp, tr)
+}
+
+// Are you JS?
+function isCode (file) {
+  return /\.js$/.test(file)
+}
+
+// a transform stream to replace simple jed translations with translated text
+function translator (dict, file, opts) {
+  var locale = i18n(dict, opts.domain)
+
+  return through(
+    function (buf, enc, next) {
+      buf = buf.toString()
+
+      var simpleTranslateRegex = /i18n\.translate\(('([^']+)'|"([^'"]+)")\)\.fetch\(\)/g
+      var matches = simpleTranslateRegex.exec(buf)
+
+      while (matches) {
+        var result = locale.translate(matches[2] || matches[3]).fetch()
+        buf = buf.replace(matches[0], result ? JSON.stringify(result) : matches[1])
+        matches = simpleTranslateRegex.exec(buf)
+      }
+
+      next(null, buf + '\n')
+    }
+  )
+}

--- a/markup.js
+++ b/markup.js
@@ -1,0 +1,55 @@
+/*
+* i18ify.markup - used at build time to replace text in templates.
+*/
+var path = require('path')
+var through = require('through2')
+var trumpet = require('trumpet')
+var i18n = require('./i18n')
+
+module.exports = function (dict, file, opts) {
+  if (!isMarkup(file)) return through()
+
+  opts = opts || {}
+
+  var key = path.relative(process.cwd(), file)
+  var tr = trumpet()
+
+  // Find elements to translate
+  tr.selectAll('[data-i18n]', function (elem) {
+
+    // Add the file path id as the value of the `data-i18n attribute
+    elem.setAttribute('data-i18n', key)
+
+    // Replace the contents with the translation
+    elem.createReadStream()
+      .pipe(translator(dict, file, opts))
+      .pipe(elem.createWriteStream())
+  })
+
+  return tr
+}
+
+// Are you html or hbs?
+function isMarkup (file) {
+  return /\.(html|hbs)$/.test(file)
+}
+
+// a transform stream to replace text with translated text
+function translator (dict, file, opts) {
+  var locale = i18n(dict, opts.domain)
+  var key = ''
+
+  return through(
+    function (buf, enc, next) {
+      key += buf.toString('utf8').trim()
+      next()
+    },
+    function (next) {
+      if (!key) return next(new Error('Empty translation key in file ' + file))
+
+      var result = locale.translate(key).fetch()
+      this.push(result || key)
+      next()
+    }
+  )
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "homepage": "https://github.com/tableflip/i18nify#readme",
   "dependencies": {
+    "duplexer": "^0.1.1",
     "jed": "^1.1.0",
+    "split": "^1.0.0",
     "through2": "^2.0.0",
     "trumpet": "^1.7.1"
   },


### PR DESCRIPTION
Simplest possible thing that could work - this adds a through stream into the pipeline that operates on `.js` files. It splits them into lines, uses a regex to search for `i18n.translate('some key').fetch()` and replaces it with the translation for 'some key'.

It doesn't support escaped quotes in strings so `i18n.translate('some key\'s').fetch()` won't be matched, but that's ok for now.
