### PR TITLE
Translate attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Browserify transform for build time i18n using browserify",
   "main": "index.js",
   "scripts": {
-    "test": "standard"
+    "test": "standard && tape test.js"
   },
   "repository": {
     "type": "git",
@@ -30,6 +30,7 @@
     "trumpet": "^1.7.1"
   },
   "devDependencies": {
-    "standard": "^5.1.1"
+    "standard": "^5.1.1",
+    "tape": "^4.2.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,71 @@
+var test = require('tape')
+var os = require('os')
+var fs = require('fs')
+var i18nify = require('./')
+
+function makeDict (lang, data) {
+  data[''] = {
+    domain: 'messages',
+    lang: lang,
+    plural_forms: 'nplurals=2; plural=(n != 1);'
+  }
+
+  var path = os.tmpdir() + '/i18nify-dict-' + Date.now()
+  fs.mkdirSync(path); fs.mkdirSync(path + '/' + lang)
+  fs.writeFileSync(path + '/' + lang + '/dict.json', JSON.stringify({messages: data}))
+  return path
+}
+
+test('Should translate text', function (t) {
+  t.plan(1)
+
+  var lang = 'es-ES'
+  var translations = {
+    'Enter the serial number': [
+      'Introduzca número de serie'
+    ]
+  }
+
+  var path = makeDict(lang, translations)
+  var tr = i18nify('test.hbs', {lang: lang, path: path})
+  var out = ''
+
+  tr.on('data', function (data) {
+    out += data
+  })
+
+  tr.on('end', function () {
+    t.equal(out, '<label data-i18n="test.hbs">Introduzca número de serie</label>')
+    t.end()
+  })
+
+  tr.write('<label data-i18n>Enter the serial number</label>')
+  tr.end()
+})
+
+test('Should translate attributes', function (t) {
+  t.plan(1)
+
+  var lang = 'es-ES'
+  var translations = {
+    'Enter the serial number': [
+      'Introduzca número de serie'
+    ]
+  }
+
+  var path = makeDict(lang, translations)
+  var tr = i18nify('test.hbs', {lang: lang, path: path})
+  var out = ''
+
+  tr.on('data', function (data) {
+    out += data
+  })
+
+  tr.on('end', function () {
+    t.equal(out, '<input type="text" placeholder="Introduzca número de serie">')
+    t.end()
+  })
+
+  tr.write('<input type="text" placeholder="Enter the serial number" data-i18n-attr="placeholder">')
+  tr.end()
+})


### PR DESCRIPTION
A port of https://github.com/tableflip/i18n-browserify/pull/11

Turns out there's no CSS selector for selecting partial attributes, so we can't do the slightly nicer "data-i18n-placeholder" to translate the placeholder attribute (at least not using trumpet).

This PR allows you to add data-i18n-attr="placeholder" to have i18ify translate the placeholder attribute.

Should you really need to, you can translate multiple attributes by space separating their names e.g. data-i18n-attr="placeholder title".

Also added tape and some tests.
